### PR TITLE
fix: Create metric without filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=propeldata.com
 NAMESPACE=propeldata
 NAME=propel
 BINARY=terraform-provider-${NAME}
-VERSION=0.0.1
+VERSION=0.0.2
 OS_ARCH=darwin_arm64
 
 default: install

--- a/propel/resource_metric.go
+++ b/propel/resource_metric.go
@@ -106,7 +106,7 @@ func resourceMetricCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	var diags diag.Diagnostics
 
-	var filters []pc.FilterInput
+	filters := make([]pc.FilterInput, 0)
 	if def, ok := d.Get("filter").([]interface{}); ok && len(def) > 0 {
 		filters = expandMetricFilters(def)
 	}


### PR DESCRIPTION
Fix bug that was preventing to create a metric without Filters