### PR TITLE
Fixes

### DIFF
--- a/propel/resource_data_source.go
+++ b/propel/resource_data_source.go
@@ -609,16 +609,56 @@ func handleS3ConnectionSettings(response *pc.DataSourceResponse, d *schema.Resou
 func resourceSnowflakeDataSourceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(graphql.Client)
 
-	if d.HasChanges("unique_name", "description") {
+	if d.HasChanges("unique_name", "description", "snowflake_connection_settings") {
 		id := d.Id()
 		uniqueName := d.Get("unique_name").(string)
 		description := d.Get("description").(string)
+
+		connectionSettings := d.Get("snowflake_connection_settings").([]interface{})[0].(map[string]interface{})
+		connectionSettingsInput := &pc.PartialSnowflakeConnectionSettingsInput{}
+
+		if def, ok := connectionSettings["account"]; ok {
+			account := def.(string)
+			connectionSettingsInput.Account = &account
+		}
+
+		if def, ok := connectionSettings["database"]; ok {
+			database := def.(string)
+			connectionSettingsInput.Database = &database
+		}
+
+		if def, ok := connectionSettings["warehouse"]; ok {
+			warehouse := def.(string)
+			connectionSettingsInput.Warehouse = &warehouse
+		}
+
+		if def, ok := connectionSettings["schema"]; ok {
+			schemaF := def.(string)
+			connectionSettingsInput.Schema = &schemaF
+		}
+
+		if def, ok := connectionSettings["role"]; ok {
+			role := def.(string)
+			connectionSettingsInput.Role = &role
+		}
+
+		if def, ok := connectionSettings["username"]; ok {
+			username := def.(string)
+			connectionSettingsInput.Username = &username
+		}
+
+		if def, ok := connectionSettings["password"]; ok {
+			password := def.(string)
+			connectionSettingsInput.Password = &password
+		}
+
 		modifyDataSource := &pc.ModifySnowflakeDataSourceInput{
 			IdOrUniqueName: &pc.IdOrUniqueName{
 				Id: &id,
 			},
-			UniqueName:  &uniqueName,
-			Description: &description,
+			UniqueName:         &uniqueName,
+			Description:        &description,
+			ConnectionSettings: connectionSettingsInput,
 		}
 
 		_, err := pc.ModifySnowflakeDataSource(ctx, c, modifyDataSource)

--- a/propel/resource_data_source.go
+++ b/propel/resource_data_source.go
@@ -552,6 +552,7 @@ func handleS3Tables(response *pc.DataSourceResponse, d *schema.ResourceData) dia
 			tables = append(tables, map[string]interface{}{
 				"id":     table.Id,
 				"name":   table.Name,
+				"path":   table.Path,
 				"column": columns,
 			})
 		}

--- a/propel/resource_metric.go
+++ b/propel/resource_metric.go
@@ -319,6 +319,48 @@ func resourceMetricRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 			filters = append(filters, filter)
 		}
+	case *pc.MetricDataSettingsAverageMetricSettings:
+		if err := d.Set("measure", s.Measure.ColumnName); err != nil {
+			return diag.FromErr(err)
+		}
+
+		for _, f := range s.Filters {
+			filter := map[string]interface{}{
+				"column":   f.Column,
+				"operator": f.Operator,
+				"value":    f.Value,
+			}
+
+			filters = append(filters, filter)
+		}
+	case *pc.MetricDataSettingsMinMetricSettings:
+		if err := d.Set("measure", s.Measure.ColumnName); err != nil {
+			return diag.FromErr(err)
+		}
+
+		for _, f := range s.Filters {
+			filter := map[string]interface{}{
+				"column":   f.Column,
+				"operator": f.Operator,
+				"value":    f.Value,
+			}
+
+			filters = append(filters, filter)
+		}
+	case *pc.MetricDataSettingsMaxMetricSettings:
+		if err := d.Set("measure", s.Measure.ColumnName); err != nil {
+			return diag.FromErr(err)
+		}
+
+		for _, f := range s.Filters {
+			filter := map[string]interface{}{
+				"column":   f.Column,
+				"operator": f.Operator,
+				"value":    f.Value,
+			}
+
+			filters = append(filters, filter)
+		}
 	}
 
 	if err := d.Set("filter", filters); err != nil {

--- a/propel_client/fragments/DataSource.fragment.graphql
+++ b/propel_client/fragments/DataSource.fragment.graphql
@@ -37,6 +37,7 @@ fragment DataSourceData on DataSource {
             tables {
                 id
                 name
+                path
                 columns {
                     name
                     type

--- a/propel_client/fragments/Metric.fragment.graphql
+++ b/propel_client/fragments/Metric.fragment.graphql
@@ -29,12 +29,43 @@ fragment MetricData on Metric {
                 ...DimensionData
             }
         }
+
         ... on CountDistinctMetricSettings {
             __typename
             filters {
                 ...FilterData
             }
             dimension {
+                ...DimensionData
+            }
+        }
+
+        ... on AverageMetricSettings {
+            __typename
+            filters {
+                ...FilterData
+            }
+            measure {
+                ...DimensionData
+            }
+        }
+
+        ... on MinMetricSettings {
+            __typename
+            filters {
+                ...FilterData
+            }
+            measure {
+                ...DimensionData
+            }
+        }
+
+        ... on MaxMetricSettings {
+            __typename
+            filters {
+                ...FilterData
+            }
+            measure {
                 ...DimensionData
             }
         }

--- a/propel_client/generated.go
+++ b/propel_client/generated.go
@@ -7746,10 +7746,206 @@ func (v *MetricDataMeasureDimension) __premarshalJSON() (*__premarshalMetricData
 // Settings for Average Metrics.
 type MetricDataSettingsAverageMetricSettings struct {
 	Typename *string `json:"__typename"`
+	// Metric Filters allow defining a Metric with a subset of records from the given Data Pool. If no Metric Filters are present, all records will be included. To filter at query time, add Dimensions and use the `filters` property on the `timeSeriesInput`, `counterInput`, or `leaderboardInput` objects. There is no need to add `filters` to be able to filter at query time.
+	Filters []*MetricDataSettingsAverageMetricSettingsFiltersFilter `json:"filters"`
+	// The Dimension to be averaged.
+	Measure *MetricDataSettingsAverageMetricSettingsMeasureDimension `json:"measure"`
 }
 
 // GetTypename returns MetricDataSettingsAverageMetricSettings.Typename, and is useful for accessing the field via an interface.
 func (v *MetricDataSettingsAverageMetricSettings) GetTypename() *string { return v.Typename }
+
+// GetFilters returns MetricDataSettingsAverageMetricSettings.Filters, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsAverageMetricSettings) GetFilters() []*MetricDataSettingsAverageMetricSettingsFiltersFilter {
+	return v.Filters
+}
+
+// GetMeasure returns MetricDataSettingsAverageMetricSettings.Measure, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsAverageMetricSettings) GetMeasure() *MetricDataSettingsAverageMetricSettingsMeasureDimension {
+	return v.Measure
+}
+
+// MetricDataSettingsAverageMetricSettingsFiltersFilter includes the requested fields of the GraphQL type Filter.
+// The GraphQL type's documentation follows.
+//
+// The fields of a filter.
+//
+// You can construct more complex filters using `and` and `or`. For example, to construct a filter equivalent to
+//
+// ```
+// (value > 0 AND value <= 100) OR status = "confirmed"
+// ```
+//
+// you could write
+//
+// ```
+// {
+// "column": "value",
+// "operator": "GREATER_THAN",
+// "value": "0",
+// "and": [{
+// "column": "value",
+// "operator": "LESS_THAN_OR_EQUAL_TO",
+// "value": "0"
+// }],
+// "or": [{
+// "column": "status",
+// "operator": "EQUALS",
+// "value": "confirmed"
+// }]
+// }
+// ```
+//
+// Note that `and` takes precedence over `or`.
+type MetricDataSettingsAverageMetricSettingsFiltersFilter struct {
+	FilterData `json:"-"`
+}
+
+// GetColumn returns MetricDataSettingsAverageMetricSettingsFiltersFilter.Column, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsAverageMetricSettingsFiltersFilter) GetColumn() string {
+	return v.FilterData.Column
+}
+
+// GetOperator returns MetricDataSettingsAverageMetricSettingsFiltersFilter.Operator, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsAverageMetricSettingsFiltersFilter) GetOperator() FilterOperator {
+	return v.FilterData.Operator
+}
+
+// GetValue returns MetricDataSettingsAverageMetricSettingsFiltersFilter.Value, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsAverageMetricSettingsFiltersFilter) GetValue() string {
+	return v.FilterData.Value
+}
+
+func (v *MetricDataSettingsAverageMetricSettingsFiltersFilter) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*MetricDataSettingsAverageMetricSettingsFiltersFilter
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.MetricDataSettingsAverageMetricSettingsFiltersFilter = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.FilterData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalMetricDataSettingsAverageMetricSettingsFiltersFilter struct {
+	Column string `json:"column"`
+
+	Operator FilterOperator `json:"operator"`
+
+	Value string `json:"value"`
+}
+
+func (v *MetricDataSettingsAverageMetricSettingsFiltersFilter) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *MetricDataSettingsAverageMetricSettingsFiltersFilter) __premarshalJSON() (*__premarshalMetricDataSettingsAverageMetricSettingsFiltersFilter, error) {
+	var retval __premarshalMetricDataSettingsAverageMetricSettingsFiltersFilter
+
+	retval.Column = v.FilterData.Column
+	retval.Operator = v.FilterData.Operator
+	retval.Value = v.FilterData.Value
+	return &retval, nil
+}
+
+// MetricDataSettingsAverageMetricSettingsMeasureDimension includes the requested fields of the GraphQL type Dimension.
+// The GraphQL type's documentation follows.
+//
+// The Dimension object that represents a column in a table.
+type MetricDataSettingsAverageMetricSettingsMeasureDimension struct {
+	DimensionData `json:"-"`
+}
+
+// GetColumnName returns MetricDataSettingsAverageMetricSettingsMeasureDimension.ColumnName, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsAverageMetricSettingsMeasureDimension) GetColumnName() string {
+	return v.DimensionData.ColumnName
+}
+
+// GetType returns MetricDataSettingsAverageMetricSettingsMeasureDimension.Type, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsAverageMetricSettingsMeasureDimension) GetType() string {
+	return v.DimensionData.Type
+}
+
+// GetIsNullable returns MetricDataSettingsAverageMetricSettingsMeasureDimension.IsNullable, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsAverageMetricSettingsMeasureDimension) GetIsNullable() *bool {
+	return v.DimensionData.IsNullable
+}
+
+// GetIsUniqueKey returns MetricDataSettingsAverageMetricSettingsMeasureDimension.IsUniqueKey, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsAverageMetricSettingsMeasureDimension) GetIsUniqueKey() *bool {
+	return v.DimensionData.IsUniqueKey
+}
+
+func (v *MetricDataSettingsAverageMetricSettingsMeasureDimension) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*MetricDataSettingsAverageMetricSettingsMeasureDimension
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.MetricDataSettingsAverageMetricSettingsMeasureDimension = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.DimensionData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalMetricDataSettingsAverageMetricSettingsMeasureDimension struct {
+	ColumnName string `json:"columnName"`
+
+	Type string `json:"type"`
+
+	IsNullable *bool `json:"isNullable"`
+
+	IsUniqueKey *bool `json:"isUniqueKey"`
+}
+
+func (v *MetricDataSettingsAverageMetricSettingsMeasureDimension) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *MetricDataSettingsAverageMetricSettingsMeasureDimension) __premarshalJSON() (*__premarshalMetricDataSettingsAverageMetricSettingsMeasureDimension, error) {
+	var retval __premarshalMetricDataSettingsAverageMetricSettingsMeasureDimension
+
+	retval.ColumnName = v.DimensionData.ColumnName
+	retval.Type = v.DimensionData.Type
+	retval.IsNullable = v.DimensionData.IsNullable
+	retval.IsUniqueKey = v.DimensionData.IsUniqueKey
+	return &retval, nil
+}
 
 // MetricDataSettingsCountDistinctMetricSettings includes the requested fields of the GraphQL type CountDistinctMetricSettings.
 // The GraphQL type's documentation follows.
@@ -8083,10 +8279,206 @@ func (v *MetricDataSettingsCountMetricSettingsFiltersFilter) __premarshalJSON() 
 // Settings for Max Metrics.
 type MetricDataSettingsMaxMetricSettings struct {
 	Typename *string `json:"__typename"`
+	// Metric Filters allow defining a Metric with a subset of records from the given Data Pool. If no Metric Filters are present, all records will be included. To filter at query time, add Dimensions and use the `filters` property on the `timeSeriesInput`, `counterInput`, or `leaderboardInput` objects. There is no need to add `filters` to be able to filter at query time.
+	Filters []*MetricDataSettingsMaxMetricSettingsFiltersFilter `json:"filters"`
+	// The Dimension to select the maximum from.
+	Measure *MetricDataSettingsMaxMetricSettingsMeasureDimension `json:"measure"`
 }
 
 // GetTypename returns MetricDataSettingsMaxMetricSettings.Typename, and is useful for accessing the field via an interface.
 func (v *MetricDataSettingsMaxMetricSettings) GetTypename() *string { return v.Typename }
+
+// GetFilters returns MetricDataSettingsMaxMetricSettings.Filters, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMaxMetricSettings) GetFilters() []*MetricDataSettingsMaxMetricSettingsFiltersFilter {
+	return v.Filters
+}
+
+// GetMeasure returns MetricDataSettingsMaxMetricSettings.Measure, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMaxMetricSettings) GetMeasure() *MetricDataSettingsMaxMetricSettingsMeasureDimension {
+	return v.Measure
+}
+
+// MetricDataSettingsMaxMetricSettingsFiltersFilter includes the requested fields of the GraphQL type Filter.
+// The GraphQL type's documentation follows.
+//
+// The fields of a filter.
+//
+// You can construct more complex filters using `and` and `or`. For example, to construct a filter equivalent to
+//
+// ```
+// (value > 0 AND value <= 100) OR status = "confirmed"
+// ```
+//
+// you could write
+//
+// ```
+// {
+// "column": "value",
+// "operator": "GREATER_THAN",
+// "value": "0",
+// "and": [{
+// "column": "value",
+// "operator": "LESS_THAN_OR_EQUAL_TO",
+// "value": "0"
+// }],
+// "or": [{
+// "column": "status",
+// "operator": "EQUALS",
+// "value": "confirmed"
+// }]
+// }
+// ```
+//
+// Note that `and` takes precedence over `or`.
+type MetricDataSettingsMaxMetricSettingsFiltersFilter struct {
+	FilterData `json:"-"`
+}
+
+// GetColumn returns MetricDataSettingsMaxMetricSettingsFiltersFilter.Column, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMaxMetricSettingsFiltersFilter) GetColumn() string {
+	return v.FilterData.Column
+}
+
+// GetOperator returns MetricDataSettingsMaxMetricSettingsFiltersFilter.Operator, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMaxMetricSettingsFiltersFilter) GetOperator() FilterOperator {
+	return v.FilterData.Operator
+}
+
+// GetValue returns MetricDataSettingsMaxMetricSettingsFiltersFilter.Value, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMaxMetricSettingsFiltersFilter) GetValue() string {
+	return v.FilterData.Value
+}
+
+func (v *MetricDataSettingsMaxMetricSettingsFiltersFilter) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*MetricDataSettingsMaxMetricSettingsFiltersFilter
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.MetricDataSettingsMaxMetricSettingsFiltersFilter = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.FilterData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalMetricDataSettingsMaxMetricSettingsFiltersFilter struct {
+	Column string `json:"column"`
+
+	Operator FilterOperator `json:"operator"`
+
+	Value string `json:"value"`
+}
+
+func (v *MetricDataSettingsMaxMetricSettingsFiltersFilter) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *MetricDataSettingsMaxMetricSettingsFiltersFilter) __premarshalJSON() (*__premarshalMetricDataSettingsMaxMetricSettingsFiltersFilter, error) {
+	var retval __premarshalMetricDataSettingsMaxMetricSettingsFiltersFilter
+
+	retval.Column = v.FilterData.Column
+	retval.Operator = v.FilterData.Operator
+	retval.Value = v.FilterData.Value
+	return &retval, nil
+}
+
+// MetricDataSettingsMaxMetricSettingsMeasureDimension includes the requested fields of the GraphQL type Dimension.
+// The GraphQL type's documentation follows.
+//
+// The Dimension object that represents a column in a table.
+type MetricDataSettingsMaxMetricSettingsMeasureDimension struct {
+	DimensionData `json:"-"`
+}
+
+// GetColumnName returns MetricDataSettingsMaxMetricSettingsMeasureDimension.ColumnName, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMaxMetricSettingsMeasureDimension) GetColumnName() string {
+	return v.DimensionData.ColumnName
+}
+
+// GetType returns MetricDataSettingsMaxMetricSettingsMeasureDimension.Type, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMaxMetricSettingsMeasureDimension) GetType() string {
+	return v.DimensionData.Type
+}
+
+// GetIsNullable returns MetricDataSettingsMaxMetricSettingsMeasureDimension.IsNullable, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMaxMetricSettingsMeasureDimension) GetIsNullable() *bool {
+	return v.DimensionData.IsNullable
+}
+
+// GetIsUniqueKey returns MetricDataSettingsMaxMetricSettingsMeasureDimension.IsUniqueKey, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMaxMetricSettingsMeasureDimension) GetIsUniqueKey() *bool {
+	return v.DimensionData.IsUniqueKey
+}
+
+func (v *MetricDataSettingsMaxMetricSettingsMeasureDimension) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*MetricDataSettingsMaxMetricSettingsMeasureDimension
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.MetricDataSettingsMaxMetricSettingsMeasureDimension = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.DimensionData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalMetricDataSettingsMaxMetricSettingsMeasureDimension struct {
+	ColumnName string `json:"columnName"`
+
+	Type string `json:"type"`
+
+	IsNullable *bool `json:"isNullable"`
+
+	IsUniqueKey *bool `json:"isUniqueKey"`
+}
+
+func (v *MetricDataSettingsMaxMetricSettingsMeasureDimension) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *MetricDataSettingsMaxMetricSettingsMeasureDimension) __premarshalJSON() (*__premarshalMetricDataSettingsMaxMetricSettingsMeasureDimension, error) {
+	var retval __premarshalMetricDataSettingsMaxMetricSettingsMeasureDimension
+
+	retval.ColumnName = v.DimensionData.ColumnName
+	retval.Type = v.DimensionData.Type
+	retval.IsNullable = v.DimensionData.IsNullable
+	retval.IsUniqueKey = v.DimensionData.IsUniqueKey
+	return &retval, nil
+}
 
 // MetricDataSettingsMetricSettings includes the requested fields of the GraphQL interface MetricSettings.
 //
@@ -8226,10 +8618,206 @@ func __marshalMetricDataSettingsMetricSettings(v *MetricDataSettingsMetricSettin
 // Settings for Min Metrics.
 type MetricDataSettingsMinMetricSettings struct {
 	Typename *string `json:"__typename"`
+	// Metric Filters allow defining a Metric with a subset of records from the given Data Pool. If no Metric Filters are present, all records will be included. To filter at query time, add Dimensions and use the `filters` property on the `timeSeriesInput`, `counterInput`, or `leaderboardInput` objects. There is no need to add `filters` to be able to filter at query time.
+	Filters []*MetricDataSettingsMinMetricSettingsFiltersFilter `json:"filters"`
+	// The Dimension to select the minimum from.
+	Measure *MetricDataSettingsMinMetricSettingsMeasureDimension `json:"measure"`
 }
 
 // GetTypename returns MetricDataSettingsMinMetricSettings.Typename, and is useful for accessing the field via an interface.
 func (v *MetricDataSettingsMinMetricSettings) GetTypename() *string { return v.Typename }
+
+// GetFilters returns MetricDataSettingsMinMetricSettings.Filters, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMinMetricSettings) GetFilters() []*MetricDataSettingsMinMetricSettingsFiltersFilter {
+	return v.Filters
+}
+
+// GetMeasure returns MetricDataSettingsMinMetricSettings.Measure, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMinMetricSettings) GetMeasure() *MetricDataSettingsMinMetricSettingsMeasureDimension {
+	return v.Measure
+}
+
+// MetricDataSettingsMinMetricSettingsFiltersFilter includes the requested fields of the GraphQL type Filter.
+// The GraphQL type's documentation follows.
+//
+// The fields of a filter.
+//
+// You can construct more complex filters using `and` and `or`. For example, to construct a filter equivalent to
+//
+// ```
+// (value > 0 AND value <= 100) OR status = "confirmed"
+// ```
+//
+// you could write
+//
+// ```
+// {
+// "column": "value",
+// "operator": "GREATER_THAN",
+// "value": "0",
+// "and": [{
+// "column": "value",
+// "operator": "LESS_THAN_OR_EQUAL_TO",
+// "value": "0"
+// }],
+// "or": [{
+// "column": "status",
+// "operator": "EQUALS",
+// "value": "confirmed"
+// }]
+// }
+// ```
+//
+// Note that `and` takes precedence over `or`.
+type MetricDataSettingsMinMetricSettingsFiltersFilter struct {
+	FilterData `json:"-"`
+}
+
+// GetColumn returns MetricDataSettingsMinMetricSettingsFiltersFilter.Column, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMinMetricSettingsFiltersFilter) GetColumn() string {
+	return v.FilterData.Column
+}
+
+// GetOperator returns MetricDataSettingsMinMetricSettingsFiltersFilter.Operator, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMinMetricSettingsFiltersFilter) GetOperator() FilterOperator {
+	return v.FilterData.Operator
+}
+
+// GetValue returns MetricDataSettingsMinMetricSettingsFiltersFilter.Value, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMinMetricSettingsFiltersFilter) GetValue() string {
+	return v.FilterData.Value
+}
+
+func (v *MetricDataSettingsMinMetricSettingsFiltersFilter) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*MetricDataSettingsMinMetricSettingsFiltersFilter
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.MetricDataSettingsMinMetricSettingsFiltersFilter = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.FilterData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalMetricDataSettingsMinMetricSettingsFiltersFilter struct {
+	Column string `json:"column"`
+
+	Operator FilterOperator `json:"operator"`
+
+	Value string `json:"value"`
+}
+
+func (v *MetricDataSettingsMinMetricSettingsFiltersFilter) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *MetricDataSettingsMinMetricSettingsFiltersFilter) __premarshalJSON() (*__premarshalMetricDataSettingsMinMetricSettingsFiltersFilter, error) {
+	var retval __premarshalMetricDataSettingsMinMetricSettingsFiltersFilter
+
+	retval.Column = v.FilterData.Column
+	retval.Operator = v.FilterData.Operator
+	retval.Value = v.FilterData.Value
+	return &retval, nil
+}
+
+// MetricDataSettingsMinMetricSettingsMeasureDimension includes the requested fields of the GraphQL type Dimension.
+// The GraphQL type's documentation follows.
+//
+// The Dimension object that represents a column in a table.
+type MetricDataSettingsMinMetricSettingsMeasureDimension struct {
+	DimensionData `json:"-"`
+}
+
+// GetColumnName returns MetricDataSettingsMinMetricSettingsMeasureDimension.ColumnName, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMinMetricSettingsMeasureDimension) GetColumnName() string {
+	return v.DimensionData.ColumnName
+}
+
+// GetType returns MetricDataSettingsMinMetricSettingsMeasureDimension.Type, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMinMetricSettingsMeasureDimension) GetType() string {
+	return v.DimensionData.Type
+}
+
+// GetIsNullable returns MetricDataSettingsMinMetricSettingsMeasureDimension.IsNullable, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMinMetricSettingsMeasureDimension) GetIsNullable() *bool {
+	return v.DimensionData.IsNullable
+}
+
+// GetIsUniqueKey returns MetricDataSettingsMinMetricSettingsMeasureDimension.IsUniqueKey, and is useful for accessing the field via an interface.
+func (v *MetricDataSettingsMinMetricSettingsMeasureDimension) GetIsUniqueKey() *bool {
+	return v.DimensionData.IsUniqueKey
+}
+
+func (v *MetricDataSettingsMinMetricSettingsMeasureDimension) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*MetricDataSettingsMinMetricSettingsMeasureDimension
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.MetricDataSettingsMinMetricSettingsMeasureDimension = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.DimensionData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalMetricDataSettingsMinMetricSettingsMeasureDimension struct {
+	ColumnName string `json:"columnName"`
+
+	Type string `json:"type"`
+
+	IsNullable *bool `json:"isNullable"`
+
+	IsUniqueKey *bool `json:"isUniqueKey"`
+}
+
+func (v *MetricDataSettingsMinMetricSettingsMeasureDimension) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *MetricDataSettingsMinMetricSettingsMeasureDimension) __premarshalJSON() (*__premarshalMetricDataSettingsMinMetricSettingsMeasureDimension, error) {
+	var retval __premarshalMetricDataSettingsMinMetricSettingsMeasureDimension
+
+	retval.ColumnName = v.DimensionData.ColumnName
+	retval.Type = v.DimensionData.Type
+	retval.IsNullable = v.DimensionData.IsNullable
+	retval.IsUniqueKey = v.DimensionData.IsUniqueKey
+	return &retval, nil
+}
 
 // MetricDataSettingsSumMetricSettings includes the requested fields of the GraphQL type SumMetricSettings.
 // The GraphQL type's documentation follows.
@@ -11695,6 +12283,33 @@ fragment MetricData on Metric {
 				... DimensionData
 			}
 		}
+		... on AverageMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MinMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MaxMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
 	}
 	type
 }
@@ -11971,6 +12586,33 @@ fragment MetricData on Metric {
 				... DimensionData
 			}
 		}
+		... on AverageMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MinMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MaxMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
 	}
 	type
 }
@@ -12244,6 +12886,33 @@ fragment MetricData on Metric {
 				... FilterData
 			}
 			dimension {
+				... DimensionData
+			}
+		}
+		... on AverageMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MinMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MaxMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
 				... DimensionData
 			}
 		}
@@ -12884,6 +13553,33 @@ fragment MetricData on Metric {
 				... DimensionData
 			}
 		}
+		... on AverageMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MinMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MaxMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
 	}
 	type
 }
@@ -13157,6 +13853,33 @@ fragment MetricData on Metric {
 				... FilterData
 			}
 			dimension {
+				... DimensionData
+			}
+		}
+		... on AverageMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MinMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MaxMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
 				... DimensionData
 			}
 		}
@@ -13721,6 +14444,33 @@ fragment MetricData on Metric {
 				... FilterData
 			}
 			dimension {
+				... DimensionData
+			}
+		}
+		... on AverageMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MinMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MaxMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
 				... DimensionData
 			}
 		}
@@ -15277,6 +16027,33 @@ fragment MetricData on Metric {
 				... DimensionData
 			}
 		}
+		... on AverageMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MinMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MaxMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
 	}
 	type
 }
@@ -15547,6 +16324,33 @@ fragment MetricData on Metric {
 				... FilterData
 			}
 			dimension {
+				... DimensionData
+			}
+		}
+		... on AverageMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MinMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MaxMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
 				... DimensionData
 			}
 		}
@@ -15840,6 +16644,33 @@ fragment MetricData on Metric {
 				... FilterData
 			}
 			dimension {
+				... DimensionData
+			}
+		}
+		... on AverageMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MinMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MaxMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
 				... DimensionData
 			}
 		}
@@ -16489,6 +17320,33 @@ fragment MetricData on Metric {
 				... FilterData
 			}
 			dimension {
+				... DimensionData
+			}
+		}
+		... on AverageMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MinMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
+				... DimensionData
+			}
+		}
+		... on MaxMetricSettings {
+			__typename
+			filters {
+				... FilterData
+			}
+			measure {
 				... DimensionData
 			}
 		}

--- a/propel_client/generated.go
+++ b/propel_client/generated.go
@@ -5779,6 +5779,8 @@ type DataSourceDataConnectionSettingsS3ConnectionSettingsTablesS3DataSourceTable
 	Id string `json:"id"`
 	// The name of the table
 	Name string `json:"name"`
+	// The path to the table's files in S3.
+	Path *string `json:"path"`
 	// All the columns present in the table
 	Columns []*DataSourceDataConnectionSettingsS3ConnectionSettingsTablesS3DataSourceTableColumnsS3DataSourceColumn `json:"columns"`
 }
@@ -5791,6 +5793,11 @@ func (v *DataSourceDataConnectionSettingsS3ConnectionSettingsTablesS3DataSourceT
 // GetName returns DataSourceDataConnectionSettingsS3ConnectionSettingsTablesS3DataSourceTable.Name, and is useful for accessing the field via an interface.
 func (v *DataSourceDataConnectionSettingsS3ConnectionSettingsTablesS3DataSourceTable) GetName() string {
 	return v.Name
+}
+
+// GetPath returns DataSourceDataConnectionSettingsS3ConnectionSettingsTablesS3DataSourceTable.Path, and is useful for accessing the field via an interface.
+func (v *DataSourceDataConnectionSettingsS3ConnectionSettingsTablesS3DataSourceTable) GetPath() *string {
+	return v.Path
 }
 
 // GetColumns returns DataSourceDataConnectionSettingsS3ConnectionSettingsTablesS3DataSourceTable.Columns, and is useful for accessing the field via an interface.
@@ -12423,6 +12430,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -12726,6 +12734,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -13029,6 +13038,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -13252,6 +13262,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -13412,6 +13423,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -13693,6 +13705,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -13996,6 +14009,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -14156,6 +14170,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -14302,6 +14317,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -14587,6 +14603,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -14805,6 +14822,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -15023,6 +15041,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -15257,6 +15276,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -15418,6 +15438,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -15554,6 +15575,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -15706,6 +15728,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -16167,6 +16190,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -16467,6 +16491,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -16787,6 +16812,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -17022,6 +17048,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -17182,6 +17209,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -17463,6 +17491,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -17623,6 +17652,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type
@@ -17769,6 +17799,7 @@ fragment DataSourceData on DataSource {
 			tables {
 				id
 				name
+				path
 				columns {
 					name
 					type


### PR DESCRIPTION
- Allow to update `filters` and `dimensions` for Metrics without the need of recreating the resource
- Add the missing sets in the resource data for Average, Min and Max Metrics, without it every time in the plan it was displaying changes for those kind of Metrics
- Allow to update connection settings for a Snowflake Data Source
- Set the S3 table path to avoid displaying changes for that in the terraform plan